### PR TITLE
Handle labels that use the older Index attribute.

### DIFF
--- a/src/label.js
+++ b/src/label.js
@@ -17,7 +17,7 @@ gifti.ATT_RED = "Red";
 gifti.ATT_GREEN = "Green";
 gifti.ATT_BLUE = "Blue";
 gifti.ATT_ALPHA = "Alpha";
-
+gifti.ATT_INDEX = "Index";
 
 
 /*** Constructor ***/
@@ -35,7 +35,7 @@ gifti.ATT_ALPHA = "Alpha";
  * @type {Function|*}
  */
 gifti.Label = gifti.Label || function (attributes) {
-    this.key = attributes[gifti.ATT_KEY];
+    this.key = attributes[gifti.ATT_KEY] || attributes[gifti.ATT_INDEX];
     this.r = parseFloat(attributes[gifti.ATT_RED]);
     this.g = parseFloat(attributes[gifti.ATT_GREEN]);
     this.b = parseFloat(attributes[gifti.ATT_BLUE]);


### PR DESCRIPTION
The GIFTI files I am using include an Index attribute rather than a Key attribute. This appears to be a valid, if obsolete, usage if I understand the documentation correctly.
